### PR TITLE
ci: ensure patch releases on main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,6 +60,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           update-file: package.json
           allow-initial-development-versions: true
+          force-bump-patch-version: true
       - run: pnpm publish --no-git-checks
         if: steps.semrel.outputs.version != ''
         env:


### PR DESCRIPTION
## Summary
- force go-semantic-release to bump patch when no qualifying commits are found

## Testing
- `pnpm lint`
- `CI=true pnpm --filter zodex test`


------
https://chatgpt.com/codex/tasks/task_e_68b092c7c4248333879e6a885e836921